### PR TITLE
fix: Rename submission secret env variable (again)

### DIFF
--- a/supabase/functions/submit-form/index.ts
+++ b/supabase/functions/submit-form/index.ts
@@ -38,7 +38,7 @@ Deno.serve(async (req: Request) => {
 
   const supabase = createClient<Database>(
     Deno.env.get('SUPABASE_URL')!,
-    Deno.env.get('SUPABASE_SUBMISSION_SECRET')!,
+    Deno.env.get('SB_SUBMISSION_SECRET')!,
   )
 
   const { error } = await supabase.from('users').insert({


### PR DESCRIPTION
Can't use `SUPABASE` as a prefix. So this is to fix what i'd done before in pr #27